### PR TITLE
MAC-17897 RTP state reset on Audio Async 

### DIFF
--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -285,6 +285,7 @@ SWITCH_DECLARE(void) switch_rtp_set_media_timeout(switch_rtp_t *rtp_session, uin
 
 SWITCH_DECLARE(switch_status_t) switch_rtp_udptl_mode(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(void) switch_rtp_reset(switch_rtp_t *rtp_session);
+SWITCH_DECLARE(void) switch_rtp_reset_stats(switch_rtp_t *rtp_session);
 
 /*!
   \brief Assign a local address to the RTP session

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -13049,6 +13049,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_receive_message(switch_core_se
 		if (switch_rtp_ready(a_engine->rtp_session)) {
 			switch_rtp_reset_jb(a_engine->rtp_session);
 			rtp_flush_read_buffer(a_engine->rtp_session, SWITCH_RTP_FLUSH_ONCE);
+			switch_rtp_reset_stats(a_engine->rtp_session);
 		}
 		goto end;
 
@@ -13056,6 +13057,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_receive_message(switch_core_se
 		if (switch_rtp_ready(v_engine->rtp_session)) {
 			switch_rtp_reset_jb(v_engine->rtp_session);
 			switch_rtp_flush(v_engine->rtp_session);
+			switch_rtp_reset_stats(v_engine->rtp_session);
 		}
 		goto end;
 	case SWITCH_MESSAGE_INDICATE_3P_MEDIA:

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -2868,6 +2868,10 @@ SWITCH_DECLARE(void) switch_rtp_reset(switch_rtp_t *rtp_session)
 	}
 
 }
+SWITCH_DECLARE(void) switch_rtp_reset_stats(switch_rtp_t *rtp_session) {
+	rtcp_stats_init(rtp_session);
+}
+
 
 SWITCH_DECLARE(void) switch_rtp_reset_media_timer(switch_rtp_t *rtp_session)
 {


### PR DESCRIPTION
MAC-17897 : Freeswitch is dropping incoming packets when we play playback or gather digit as per https://github.com/signalwire/freeswitch/issues/943 and causing jitter/packet lost/ fraction lost on Sender RTCP message. 

This PR is to reset RTP stats which being use to calculate  Sender RTCP message. 

